### PR TITLE
Bump compileSdkVersion to 31

### DIFF
--- a/libphonenumber_plugin/android/build.gradle
+++ b/libphonenumber_plugin/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This PR fixes https://github.com/natintosh/plugin_libphonenumber/issues/6 issue by upgrading Android compileSdkVersion to 31.