### PR TITLE
Adding try in SwiftLibphonenumberPlugin.swift

### DIFF
--- a/libphonenumber_plugin/ios/Classes/SwiftLibphonenumberPlugin.swift
+++ b/libphonenumber_plugin/ios/Classes/SwiftLibphonenumberPlugin.swift
@@ -90,7 +90,7 @@ public class SwiftLibphonenumberPlugin: NSObject, FlutterPlugin {
         do {
             let p : NBPhoneNumber = try phoneUtils.parse(phoneNumber, defaultRegion: isoCode.uppercased())
             
-            let regionCode : String? = phoneUtils.getRegionCode(for: p)
+            let regionCode : String? = try phoneUtils.getRegionCode(for: p)
             let countryCode : String? = p.countryCode.stringValue as String
             let formattedNumber : String? = try phoneUtils.format(p, numberFormat: NBEPhoneNumberFormat.NATIONAL)
             


### PR DESCRIPTION
In some cases, the phone crashes if the method `phoneUtils.getRegionCode(for: p)` fails.