### PR TITLE
Update build.gradle - added namespace to for gradle 8.0 and above

### DIFF
--- a/libphonenumber_plugin/android/build.gradle
+++ b/libphonenumber_plugin/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.example.libphonenumber_plugin'
+    
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
A problem occurred configuring project ':libphonenumber_plugin'.
  Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
     Namespace not specified. Please specify a namespace in the module's build.gradle file like so:
      android {
          namespace 'com.example.namespace'
      }