### PR TITLE
upgrade: migrate from package:js to dart:js_interop

### DIFF
--- a/libphonenumber_platform_interface/lib/src/utils/enums/country_code_source.dart
+++ b/libphonenumber_platform_interface/lib/src/utils/enums/country_code_source.dart
@@ -11,6 +11,7 @@
 ///  FROM_NUMBER_WITHOUT_PLUS_SIGN: 10,
 ///  FROM_DEFAULT_COUNTRY: 20
 /// };
+library;
 
 enum CountryCodeSource {
   UNSPECIFIED(value: 0),

--- a/libphonenumber_platform_interface/lib/src/utils/enums/phone_number_format.dart
+++ b/libphonenumber_platform_interface/lib/src/utils/enums/phone_number_format.dart
@@ -22,6 +22,7 @@
 ///   NATIONAL: 2,
 ///   RFC3966: 3
 /// };
+library;
 
 enum PhoneNumberFormat {
   E164(value: 0), //: 0,

--- a/libphonenumber_platform_interface/lib/src/utils/enums/phone_number_type.dart
+++ b/libphonenumber_platform_interface/lib/src/utils/enums/phone_number_type.dart
@@ -35,6 +35,7 @@
 ///   // patterns for a specific region.
 ///   UNKNOWN: -1
 /// };
+library;
 
 enum PhoneNumberType {
   FIXED_LINE(value: 0), // : 0,

--- a/libphonenumber_platform_interface/lib/src/utils/enums/short_number_cost.dart
+++ b/libphonenumber_platform_interface/lib/src/utils/enums/short_number_cost.dart
@@ -9,6 +9,7 @@
 ///  PREMIUM_RATE: 2,
 ///  UNKNOWN_COST: 3
 /// };
+library;
 
 enum ShortNumberCost {
   TOLL_FREE(value: 0),

--- a/libphonenumber_platform_interface/test/libphonenumber_platform_interface_method_channel_test.dart
+++ b/libphonenumber_platform_interface/test/libphonenumber_platform_interface_method_channel_test.dart
@@ -10,7 +10,8 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (methodCall) async {
       switch (methodCall.method) {
         case 'formatAsYouType':
           return '+234 808 012 3456';
@@ -31,11 +32,13 @@ void main() {
         case 'getFormattedExampleNumber':
           return '+234 808 012 3456';
       }
+      return null;
     });
   });
 
   tearDown(() {
-    channel.setMockMethodCallHandler(null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   test('TEST formatAsYouType', () async {
@@ -65,8 +68,8 @@ void main() {
   });
 
   test('TEST normalizePhoneNumber', () async {
-    final normalizedNumber =
-        await platform.normalizePhoneNumber('+2348080123456', 'NG', PhoneNumberFormat.E164);
+    final normalizedNumber = await platform.normalizePhoneNumber(
+        '+2348080123456', 'NG', PhoneNumberFormat.E164);
 
     expect(normalizedNumber, '+2348080123456');
   });

--- a/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
+++ b/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
@@ -1,4 +1,4 @@
-part of libphonenumber_interop;
+part of 'libphonenumber_interop.dart';
 
 @JS('AsYouTypeFormatter')
 class AsYouTypeFormatterJsImpl {

--- a/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
+++ b/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
@@ -1,7 +1,6 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('AsYouTypeFormatter')
-@staticInterop
 class AsYouTypeFormatterJsImpl {
   external AsYouTypeFormatterJsImpl(String regionCode);
 

--- a/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
+++ b/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
@@ -1,6 +1,7 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('AsYouTypeFormatter')
+@staticInterop
 class AsYouTypeFormatterJsImpl {
   external AsYouTypeFormatterJsImpl(String regionCode);
 

--- a/libphonenumber_web/lib/src/interop/libphonenumber_interop.dart
+++ b/libphonenumber_web/lib/src/interop/libphonenumber_interop.dart
@@ -1,11 +1,12 @@
 @JS('libphonenumber')
 library libphonenumber_interop;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
+
 import 'package:libphonenumber_web/src/interop/utils/stringbuffer.dart';
 
 part 'asyoutypeformatter_interop.dart';
+part 'phonemetadata_interop.dart';
 part 'phonenumber_interop.dart';
 part 'phonenumberutil_interop.dart';
-part 'phonemetadata_interop.dart';
 part 'shortnumberinfo_interop.dart';

--- a/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
@@ -1,7 +1,6 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('NumberFormat')
-@staticInterop
 class NumberFormatJsImpl {
   @JS('getPattern')
   external String getPattern();
@@ -113,7 +112,6 @@ class NumberFormatJsImpl {
 }
 
 @JS('PhoneNumberDesc')
-@staticInterop
 class PhoneNumberDescJsImpl {
   @JS('getNationalNumberPattern')
   external String getNationalNumberPattern();
@@ -195,7 +193,6 @@ class PhoneNumberDescJsImpl {
 }
 
 @JS('PhoneMetadata')
-@staticInterop
 class PhoneMetadataJsImpl {
   @JS('getGeneralDesc')
   external PhoneNumberDescJsImpl getGeneralDesc();
@@ -763,7 +760,6 @@ class PhoneMetadataJsImpl {
 }
 
 @JS('PhoneMetadataCollection')
-@staticInterop
 class PhoneMetadataCollectionJsImpl {
   @JS('getMetadata')
   external PhoneMetadataJsImpl getMetadata(int index);

--- a/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
@@ -1,6 +1,7 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('NumberFormat')
+@staticInterop
 class NumberFormatJsImpl {
   @JS('getPattern')
   external String getPattern();
@@ -112,6 +113,7 @@ class NumberFormatJsImpl {
 }
 
 @JS('PhoneNumberDesc')
+@staticInterop
 class PhoneNumberDescJsImpl {
   @JS('getNationalNumberPattern')
   external String getNationalNumberPattern();
@@ -193,6 +195,7 @@ class PhoneNumberDescJsImpl {
 }
 
 @JS('PhoneMetadata')
+@staticInterop
 class PhoneMetadataJsImpl {
   @JS('getGeneralDesc')
   external PhoneNumberDescJsImpl getGeneralDesc();
@@ -760,6 +763,7 @@ class PhoneMetadataJsImpl {
 }
 
 @JS('PhoneMetadataCollection')
+@staticInterop
 class PhoneMetadataCollectionJsImpl {
   @JS('getMetadata')
   external PhoneMetadataJsImpl getMetadata(int index);

--- a/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
@@ -1,4 +1,4 @@
-part of libphonenumber_interop;
+part of 'libphonenumber_interop.dart';
 
 @JS('NumberFormat')
 class NumberFormatJsImpl {

--- a/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
@@ -1,6 +1,7 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('PhoneNumber')
+@staticInterop
 class PhoneNumberJsImpl {
   @JS('getCountryCode')
   external int getCountryCode();

--- a/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
@@ -1,7 +1,6 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('PhoneNumber')
-@staticInterop
 class PhoneNumberJsImpl {
   @JS('getCountryCode')
   external int getCountryCode();

--- a/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
@@ -1,4 +1,4 @@
-part of libphonenumber_interop;
+part of 'libphonenumber_interop.dart';
 
 @JS('PhoneNumber')
 class PhoneNumberJsImpl {

--- a/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
@@ -1,4 +1,4 @@
-part of libphonenumber_interop;
+part of 'libphonenumber_interop.dart';
 
 @JS('PhoneNumberUtil')
 class PhoneNumberUtilJsImpl {

--- a/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
@@ -1,7 +1,6 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('PhoneNumberUtil')
-@staticInterop
 class PhoneNumberUtilJsImpl {
   external PhoneNumberUtilJsImpl._();
 

--- a/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
@@ -1,6 +1,7 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('PhoneNumberUtil')
+@staticInterop
 class PhoneNumberUtilJsImpl {
   external PhoneNumberUtilJsImpl._();
 

--- a/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
+++ b/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
@@ -1,7 +1,6 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('ShortNumberInfo')
-@staticInterop
 class ShortNumberInfoJsImpl {
   @JS('getInstance')
   external static ShortNumberInfoJsImpl getInstance();

--- a/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
+++ b/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
@@ -1,4 +1,4 @@
-part of libphonenumber_interop;
+part of 'libphonenumber_interop.dart';
 
 @JS('ShortNumberInfo')
 class ShortNumberInfoJsImpl {

--- a/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
+++ b/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
@@ -1,6 +1,7 @@
 part of 'libphonenumber_interop.dart';
 
 @JS('ShortNumberInfo')
+@staticInterop
 class ShortNumberInfoJsImpl {
   @JS('getInstance')
   external static ShortNumberInfoJsImpl getInstance();

--- a/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
+++ b/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
@@ -3,7 +3,7 @@
 @JS()
 library stringbuffer;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('StringBuffer')
 class StringBufferJsImpl {

--- a/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
+++ b/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
@@ -6,7 +6,6 @@ library stringbuffer;
 import 'dart:js_interop';
 
 @JS('StringBuffer')
-@staticInterop
 class StringBufferJsImpl {
   external StringBufferJsImpl(dynamic optA1, [dynamic varArgs = '']);
 

--- a/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
+++ b/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
@@ -6,6 +6,7 @@ library stringbuffer;
 import 'dart:js_interop';
 
 @JS('StringBuffer')
+@staticInterop
 class StringBufferJsImpl {
   external StringBufferJsImpl(dynamic optA1, [dynamic varArgs = '']);
 

--- a/libphonenumber_web/pubspec.yaml
+++ b/libphonenumber_web/pubspec.yaml
@@ -12,8 +12,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-
-  js: ^0.6.7
   libphonenumber_platform_interface: ^0.4.2
 
 dev_dependencies:


### PR DESCRIPTION
"The Dart team recently overhauled the collection of features and APIs that allow developers access to JavaScript and browser bindings in their Dart code. This next generation of web interop not only improves user experience, but also enables Wasm support, aligning Dart with the future of the Web."

https://dart.dev/interop/js-interop