### PR TITLE
Migrate libphonenumber_web to Next-generation JS interop

### DIFF
--- a/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
+++ b/libphonenumber_web/lib/src/interop/asyoutypeformatter_interop.dart
@@ -1,18 +1,18 @@
-part of libphonenumber_interop;
+import 'dart:js_interop';
 
-@JS('AsYouTypeFormatter')
-class AsYouTypeFormatterJsImpl {
+@JS('libphonenumber.AsYouTypeFormatter')
+extension type AsYouTypeFormatterJsImpl._(JSObject _) implements JSObject {
   external AsYouTypeFormatterJsImpl(String regionCode);
 
   @JS('clear')
   external void clear();
 
   @JS('inputDigit')
-  external String inputDigit(String nextChar);
+  external JSString inputDigit(JSString nextChar);
 
   @JS('inputDigitAndRememberPosition')
-  external String inputDigitAndRememberPosition(String nextChar);
+  external JSString inputDigitAndRememberPosition(JSString nextChar);
 
   @JS('getRememberedPosition')
-  external int getRememberedPosition();
+  external JSNumber getRememberedPosition();
 }

--- a/libphonenumber_web/lib/src/interop/libphonenumber_interop.dart
+++ b/libphonenumber_web/lib/src/interop/libphonenumber_interop.dart
@@ -1,11 +1,6 @@
-@JS('libphonenumber')
-library libphonenumber_interop;
-
-import 'package:js/js.dart';
-import 'package:libphonenumber_web/src/interop/utils/stringbuffer.dart';
-
-part 'asyoutypeformatter_interop.dart';
-part 'phonenumber_interop.dart';
-part 'phonenumberutil_interop.dart';
-part 'phonemetadata_interop.dart';
-part 'shortnumberinfo_interop.dart';
+export 'asyoutypeformatter_interop.dart';
+export 'phonenumber_interop.dart';
+export 'phonenumberutil_interop.dart';
+export 'phonemetadata_interop.dart';
+export 'shortnumberinfo_interop.dart';
+export 'package:libphonenumber_web/src/interop/utils/stringbuffer.dart';

--- a/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonemetadata_interop.dart
@@ -1,199 +1,199 @@
-part of libphonenumber_interop;
+import 'dart:js_interop';
 
-@JS('NumberFormat')
-class NumberFormatJsImpl {
+@JS('libphonenumber.NumberFormat')
+extension type NumberFormatJsImpl._(JSObject _) implements JSObject {
   @JS('getPattern')
-  external String getPattern();
+  external JSString getPattern();
 
   @JS('getPatternOrDefault')
-  external String getPatternOrDefault();
+  external JSString getPatternOrDefault();
 
   @JS('setPattern')
-  external void setPattern(String value);
+  external void setPattern(JSString value);
 
   @JS('hasPattern')
-  external bool hasPattern();
+  external JSBoolean hasPattern();
 
   @JS('patternCount')
-  external int patternCount();
+  external JSNumber patternCount();
 
   @JS('clearPattern')
   external void clearPattern();
 
   @JS('getFormat')
-  external String getFormat();
+  external JSString getFormat();
 
   @JS('getFormatOrDefault')
-  external String getFormatOrDefault();
+  external JSString getFormatOrDefault();
 
   @JS('setFormat')
-  external void setFormat(String value);
+  external void setFormat(JSString value);
 
   @JS('hasFormat')
-  external bool hasFormat();
+  external JSBoolean hasFormat();
 
   @JS('formatCount')
-  external int formatCount();
+  external JSNumber formatCount();
 
   @JS('clearFormat')
   external void clearFormat();
 
   @JS('getLeadingDigitsPattern')
-  external String getLeadingDigitsPattern(int index);
+  external JSString getLeadingDigitsPattern(JSNumber index);
 
   @JS('addLeadingDigitsPattern')
-  external void addLeadingDigitsPattern(String value);
+  external void addLeadingDigitsPattern(JSString value);
 
   @JS('leadingDigitsPatternArray')
-  external List<String> leadingDigitsPatternArray();
+  external JSArray leadingDigitsPatternArray();
 
   @JS('hasLeadingDigitsPattern')
-  external bool hasLeadingDigitsPattern();
+  external JSBoolean hasLeadingDigitsPattern();
 
   @JS('leadingDigitsPatternCount')
-  external int leadingDigitsPatternCount();
+  external JSNumber leadingDigitsPatternCount();
 
   @JS('clearLeadingDigitsPattern')
   external void clearLeadingDigitsPattern();
 
   @JS('getNationalPrefixFormattingRule')
-  external String getNationalPrefixFormattingRule();
+  external JSString getNationalPrefixFormattingRule();
 
   @JS('getNationalPrefixFormattingRuleOrDefault')
-  external String getNationalPrefixFormattingRuleOrDefault();
+  external JSString getNationalPrefixFormattingRuleOrDefault();
 
   @JS('setNationalPrefixFormattingRule')
-  external void setNationalPrefixFormattingRule(String value);
+  external void setNationalPrefixFormattingRule(JSString value);
 
   @JS('hasNationalPrefixFormattingRule')
-  external bool hasNationalPrefixFormattingRule();
+  external JSBoolean hasNationalPrefixFormattingRule();
 
   @JS('nationalPrefixFormattingRuleCount')
-  external int nationalPrefixFormattingRuleCount();
+  external JSNumber nationalPrefixFormattingRuleCount();
 
   @JS('clearNationalPrefixFormattingRule')
   external void clearNationalPrefixFormattingRule();
 
   @JS('getNationalPrefixOptionalWhenFormatting')
-  external bool getNationalPrefixOptionalWhenFormatting();
+  external JSBoolean getNationalPrefixOptionalWhenFormatting();
 
   @JS('getNationalPrefixOptionalWhenFormattingOrDefault')
-  external bool getNationalPrefixOptionalWhenFormattingOrDefault();
+  external JSBoolean getNationalPrefixOptionalWhenFormattingOrDefault();
 
   @JS('setNationalPrefixOptionalWhenFormatting')
-  external void setNationalPrefixOptionalWhenFormatting(bool value);
+  external void setNationalPrefixOptionalWhenFormatting(JSBoolean value);
 
   @JS('hasNationalPrefixOptionalWhenFormatting')
-  external bool hasNationalPrefixOptionalWhenFormatting();
+  external JSBoolean hasNationalPrefixOptionalWhenFormatting();
 
   @JS('nationalPrefixOptionalWhenFormattingCount')
-  external int nationalPrefixOptionalWhenFormattingCount();
+  external JSNumber nationalPrefixOptionalWhenFormattingCount();
 
   @JS('clearNationalPrefixOptionalWhenFormatting')
   external void clearNationalPrefixOptionalWhenFormatting();
 
   @JS('getDomesticCarrierCodeFormattingRule')
-  external String getDomesticCarrierCodeFormattingRule();
+  external JSString getDomesticCarrierCodeFormattingRule();
 
   @JS('getDomesticCarrierCodeFormattingRuleOrDefault')
-  external String getDomesticCarrierCodeFormattingRuleOrDefault();
+  external JSString getDomesticCarrierCodeFormattingRuleOrDefault();
 
   @JS('setDomesticCarrierCodeFormattingRule')
-  external void setDomesticCarrierCodeFormattingRule(String value);
+  external void setDomesticCarrierCodeFormattingRule(JSString value);
 
   @JS('hasDomesticCarrierCodeFormattingRule')
-  external bool hasDomesticCarrierCodeFormattingRule();
+  external JSBoolean hasDomesticCarrierCodeFormattingRule();
 
   @JS('domesticCarrierCodeFormattingRuleCount')
-  external int domesticCarrierCodeFormattingRuleCount();
+  external JSNumber domesticCarrierCodeFormattingRuleCount();
 
   @JS('clearDomesticCarrierCodeFormattingRule')
   external void clearDomesticCarrierCodeFormattingRule();
 }
 
-@JS('PhoneNumberDesc')
-class PhoneNumberDescJsImpl {
+@JS('libphonenumber.PhoneNumberDesc')
+extension type PhoneNumberDescJsImpl._(JSObject _) implements JSObject {
   @JS('getNationalNumberPattern')
-  external String getNationalNumberPattern();
+  external JSString getNationalNumberPattern();
 
   @JS('getNationalNumberPatternOrDefault')
-  external String getNationalNumberPatternOrDefault();
+  external JSString getNationalNumberPatternOrDefault();
 
   @JS('setNationalNumberPattern')
-  external void setNationalNumberPattern(String value);
+  external void setNationalNumberPattern(JSString value);
 
   @JS('hasNationalNumberPattern')
-  external bool hasNationalNumberPattern();
+  external JSBoolean hasNationalNumberPattern();
 
   @JS('nationalNumberPatternCount')
-  external int nationalNumberPatternCount();
+  external JSNumber nationalNumberPatternCount();
 
   @JS('clearNationalNumberPattern')
   external void clearNationalNumberPattern();
 
   @JS('getPossibleLength')
-  external int getPossibleLength(int index);
+  external JSNumber getPossibleLength(JSNumber index);
 
   @JS('getPossibleLengthOrDefault')
-  external int getPossibleLengthOrDefault(int index);
+  external JSNumber getPossibleLengthOrDefault(JSNumber index);
 
   @JS('addPossibleLength')
-  external void addPossibleLength(int value);
+  external void addPossibleLength(JSNumber value);
 
   @JS('possibleLengthArray')
-  external List<int> possibleLengthArray();
+  external JSArray possibleLengthArray();
 
   @JS('hasPossibleLength')
-  external bool hasPossibleLength();
+  external JSBoolean hasPossibleLength();
 
   @JS('possibleLengthCount')
-  external int possibleLengthCount();
+  external JSNumber possibleLengthCount();
 
   @JS('clearPossibleLength')
   external void clearPossibleLength();
 
   @JS('getPossibleLengthLocalOnly')
-  external int getPossibleLengthLocalOnly(int index);
+  external JSNumber getPossibleLengthLocalOnly(JSNumber index);
 
   @JS('getPossibleLengthLocalOnlyOrDefault')
-  external int getPossibleLengthLocalOnlyOrDefault(int index);
+  external JSNumber getPossibleLengthLocalOnlyOrDefault(JSNumber index);
 
   @JS('addPossibleLengthLocalOnly')
-  external void addPossibleLengthLocalOnly(int value);
+  external void addPossibleLengthLocalOnly(JSNumber value);
 
   @JS('possibleLengthLocalOnlyArray')
-  external List<int> possibleLengthLocalOnlyArray();
+  external JSArray possibleLengthLocalOnlyArray();
 
   @JS('hasPossibleLengthLocalOnly')
-  external bool hasPossibleLengthLocalOnly();
+  external JSBoolean hasPossibleLengthLocalOnly();
 
   @JS('possibleLengthLocalOnlyCount')
-  external int possibleLengthLocalOnlyCount();
+  external JSNumber possibleLengthLocalOnlyCount();
 
   @JS('clearPossibleLengthLocalOnly')
   external void clearPossibleLengthLocalOnly();
 
   @JS('getExampleNumber')
-  external String getExampleNumber();
+  external JSString getExampleNumber();
 
   @JS('getExampleNumberOrDefault')
-  external String getExampleNumberOrDefault();
+  external JSString getExampleNumberOrDefault();
 
   @JS('setExampleNumber')
-  external void setExampleNumber(String value);
+  external void setExampleNumber(JSString value);
 
   @JS('hasExampleNumber')
-  external bool hasExampleNumber();
+  external JSBoolean hasExampleNumber();
 
   @JS('exampleNumberCount')
-  external int exampleNumberCount();
+  external JSNumber exampleNumberCount();
 
   @JS('clearExampleNumber')
   external void clearExampleNumber();
 }
 
-@JS('PhoneMetadata')
-class PhoneMetadataJsImpl {
+@JS('libphonenumber.PhoneMetadata')
+extension type PhoneMetadataJsImpl._(JSObject _) implements JSObject {
   @JS('getGeneralDesc')
   external PhoneNumberDescJsImpl getGeneralDesc();
 
@@ -204,10 +204,10 @@ class PhoneMetadataJsImpl {
   external void setGeneralDesc(PhoneNumberDescJsImpl value);
 
   @JS('hasGeneralDesc')
-  external bool hasGeneralDesc();
+  external JSBoolean hasGeneralDesc();
 
   @JS('generalDescCount')
-  external int generalDescCount();
+  external JSNumber generalDescCount();
 
   @JS('clearGeneralDesc')
   external void clearGeneralDesc();
@@ -222,10 +222,10 @@ class PhoneMetadataJsImpl {
   external void setFixedLine(PhoneNumberDescJsImpl value);
 
   @JS('hasFixedLine')
-  external bool hasFixedLine();
+  external JSBoolean hasFixedLine();
 
   @JS('fixedLineCount')
-  external int fixedLineCount();
+  external JSNumber fixedLineCount();
 
   @JS('clearFixedLine')
   external void clearFixedLine();
@@ -240,10 +240,10 @@ class PhoneMetadataJsImpl {
   external void setMobile(PhoneNumberDescJsImpl value);
 
   @JS('hasMobile')
-  external bool hasMobile();
+  external JSBoolean hasMobile();
 
   @JS('mobileCount')
-  external int mobileCount();
+  external JSNumber mobileCount();
 
   @JS('clearMobile')
   external void clearMobile();
@@ -258,10 +258,10 @@ class PhoneMetadataJsImpl {
   external void setTollFree(PhoneNumberDescJsImpl value);
 
   @JS('hasTollFree')
-  external bool hasTollFree();
+  external JSBoolean hasTollFree();
 
   @JS('tollFreeCount')
-  external int tollFreeCount();
+  external JSNumber tollFreeCount();
 
   @JS('clearTollFree')
   external void clearTollFree();
@@ -276,10 +276,10 @@ class PhoneMetadataJsImpl {
   external void setPremiumRate(PhoneNumberDescJsImpl value);
 
   @JS('hasPremiumRate')
-  external bool hasPremiumRate();
+  external JSBoolean hasPremiumRate();
 
   @JS('premiumRateCount')
-  external int premiumRateCount();
+  external JSNumber premiumRateCount();
 
   @JS('clearPremiumRate')
   external void clearPremiumRate();
@@ -294,10 +294,10 @@ class PhoneMetadataJsImpl {
   external void setSharedCost(PhoneNumberDescJsImpl value);
 
   @JS('hasSharedCost')
-  external bool hasSharedCost();
+  external JSBoolean hasSharedCost();
 
   @JS('sharedCostCount')
-  external int sharedCostCount();
+  external JSNumber sharedCostCount();
 
   @JS('clearSharedCost')
   external void clearSharedCost();
@@ -312,10 +312,10 @@ class PhoneMetadataJsImpl {
   external void setPersonalNumber(PhoneNumberDescJsImpl value);
 
   @JS('hasPersonalNumber')
-  external bool hasPersonalNumber();
+  external JSBoolean hasPersonalNumber();
 
   @JS('personalNumberCount')
-  external int personalNumberCount();
+  external JSNumber personalNumberCount();
 
   @JS('clearPersonalNumber')
   external void clearPersonalNumber();
@@ -330,10 +330,10 @@ class PhoneMetadataJsImpl {
   external void setVoip(PhoneNumberDescJsImpl value);
 
   @JS('hasVoip')
-  external bool hasVoip();
+  external JSBoolean hasVoip();
 
   @JS('voipCount')
-  external int voipCount();
+  external JSNumber voipCount();
 
   @JS('clearVoip')
   external void clearVoip();
@@ -348,10 +348,10 @@ class PhoneMetadataJsImpl {
   external void setPager(PhoneNumberDescJsImpl value);
 
   @JS('hasPager')
-  external bool hasPager();
+  external JSBoolean hasPager();
 
   @JS('pagerCount')
-  external int pagerCount();
+  external JSNumber pagerCount();
 
   @JS('clearPager')
   external void clearPager();
@@ -366,10 +366,10 @@ class PhoneMetadataJsImpl {
   external void setUan(PhoneNumberDescJsImpl value);
 
   @JS('hasUan')
-  external bool hasUan();
+  external JSBoolean hasUan();
 
   @JS('uanCount')
-  external int uanCount();
+  external JSNumber uanCount();
 
   @JS('clearUan')
   external void clearUan();
@@ -384,10 +384,10 @@ class PhoneMetadataJsImpl {
   external void setEmergency(PhoneNumberDescJsImpl value);
 
   @JS('hasEmergency')
-  external bool hasEmergency();
+  external JSBoolean hasEmergency();
 
   @JS('emergencyCount')
-  external int emergencyCount();
+  external JSNumber emergencyCount();
 
   @JS('clearEmergency')
   external void clearEmergency();
@@ -402,10 +402,10 @@ class PhoneMetadataJsImpl {
   external void setVoicemail(PhoneNumberDescJsImpl value);
 
   @JS('hasVoicemail')
-  external bool hasVoicemail();
+  external JSBoolean hasVoicemail();
 
   @JS('voicemailCount')
-  external int voicemailCount();
+  external JSNumber voicemailCount();
 
   @JS('clearVoicemail')
   external void clearVoicemail();
@@ -420,10 +420,10 @@ class PhoneMetadataJsImpl {
   external void setShortCode(PhoneNumberDescJsImpl value);
 
   @JS('hasShortCode')
-  external bool hasShortCode();
+  external JSBoolean hasShortCode();
 
   @JS('shortCodeCount')
-  external int shortCodeCount();
+  external JSNumber shortCodeCount();
 
   @JS('clearShortCode')
   external void clearShortCode();
@@ -438,10 +438,10 @@ class PhoneMetadataJsImpl {
   external void setStandardRate(PhoneNumberDescJsImpl value);
 
   @JS('hasStandardRate')
-  external bool hasStandardRate();
+  external JSBoolean hasStandardRate();
 
   @JS('standardRateCount')
-  external int standardRateCount();
+  external JSNumber standardRateCount();
 
   @JS('clearStandardRate')
   external void clearStandardRate();
@@ -456,10 +456,10 @@ class PhoneMetadataJsImpl {
   external void setCarrierSpecific(PhoneNumberDescJsImpl value);
 
   @JS('hasCarrierSpecific')
-  external bool hasCarrierSpecific();
+  external JSBoolean hasCarrierSpecific();
 
   @JS('carrierSpecificCount')
-  external int carrierSpecificCount();
+  external JSNumber carrierSpecificCount();
 
   @JS('clearCarrierSpecific')
   external void clearCarrierSpecific();
@@ -474,10 +474,10 @@ class PhoneMetadataJsImpl {
   external void setSmsServices(PhoneNumberDescJsImpl value);
 
   @JS('hasSmsServices')
-  external bool hasSmsServices();
+  external JSBoolean hasSmsServices();
 
   @JS('smsServicesCount')
-  external int smsServicesCount();
+  external JSNumber smsServicesCount();
 
   @JS('clearSmsServices')
   external void clearSmsServices();
@@ -492,10 +492,10 @@ class PhoneMetadataJsImpl {
   external void setNoInternationalDialling(PhoneNumberDescJsImpl value);
 
   @JS('hasNoInternationalDialling')
-  external bool hasNoInternationalDialling();
+  external JSBoolean hasNoInternationalDialling();
 
   @JS('noInternationalDiallingCount')
-  external int noInternationalDiallingCount();
+  external JSNumber noInternationalDiallingCount();
 
   @JS('clearNoInternationalDialling')
   external void clearNoInternationalDialling();
@@ -510,274 +510,274 @@ class PhoneMetadataJsImpl {
   external void setId(PhoneNumberDescJsImpl value);
 
   @JS('hasId')
-  external bool hasId();
+  external JSBoolean hasId();
 
   @JS('idCount')
-  external int idCount();
+  external JSNumber idCount();
 
   @JS('clearId')
   external void clearId();
 
   @JS('getCountryCode')
-  external int getCountryCode();
+  external JSNumber getCountryCode();
 
   @JS('getCountryCodeOrDefault')
-  external int getCountryCodeOrDefault();
+  external JSNumber getCountryCodeOrDefault();
 
   @JS('setCountryCode')
-  external void setCountryCode(int value);
+  external void setCountryCode(JSNumber value);
 
   @JS('hasCountryCode')
-  external bool hasCountryCode();
+  external JSBoolean hasCountryCode();
 
   @JS('countryCodeCount')
-  external int countryCodeCount();
+  external JSNumber countryCodeCount();
 
   @JS('clearCountryCode')
   external void clearCountryCode();
 
   @JS('getInternationalPrefix')
-  external String getInternationalPrefix();
+  external JSString getInternationalPrefix();
 
   @JS('getInternationalPrefixOrDefault')
-  external String getInternationalPrefixOrDefault();
+  external JSString getInternationalPrefixOrDefault();
 
   @JS('setInternationalPrefix')
-  external void setInternationalPrefix(String value);
+  external void setInternationalPrefix(JSString value);
 
   @JS('hasInternationalPrefix')
-  external bool hasInternationalPrefix();
+  external JSBoolean hasInternationalPrefix();
 
   @JS('internationalPrefixCount')
-  external int internationalPrefixCount();
+  external JSNumber internationalPrefixCount();
 
   @JS('clearInternationalPrefix')
   external void clearInternationalPrefix();
 
   @JS('getPreferredInternationalPrefix')
-  external String getPreferredInternationalPrefix();
+  external JSString getPreferredInternationalPrefix();
 
   @JS('getPreferredInternationalPrefixOrDefault')
-  external String getPreferredInternationalPrefixOrDefault();
+  external JSString getPreferredInternationalPrefixOrDefault();
 
   @JS('setPreferredInternationalPrefix')
-  external void setPreferredInternationalPrefix(String value);
+  external void setPreferredInternationalPrefix(JSString value);
 
   @JS('hasPreferredInternationalPrefix')
-  external bool hasPreferredInternationalPrefix();
+  external JSBoolean hasPreferredInternationalPrefix();
 
   @JS('preferredInternationalPrefixCount')
-  external int preferredInternationalPrefixCount();
+  external JSNumber preferredInternationalPrefixCount();
 
   @JS('clearPreferredInternationalPrefix')
   external void clearPreferredInternationalPrefix();
 
   @JS('getNationalPrefix')
-  external String getNationalPrefix();
+  external JSString getNationalPrefix();
 
   @JS('getNationalPrefixOrDefault')
-  external String getNationalPrefixOrDefault();
+  external JSString getNationalPrefixOrDefault();
 
   @JS('setNationalPrefix')
-  external void setNationalPrefix(String value);
+  external void setNationalPrefix(JSString value);
 
   @JS('hasNationalPrefix')
-  external bool hasNationalPrefix();
+  external JSBoolean hasNationalPrefix();
 
   @JS('nationalPrefixCount')
-  external int nationalPrefixCount();
+  external JSNumber nationalPrefixCount();
 
   @JS('clearNationalPrefix')
   external void clearNationalPrefix();
 
   @JS('getPreferredExtnPrefix')
-  external String getPreferredExtnPrefix();
+  external JSString getPreferredExtnPrefix();
 
   @JS('getPreferredExtnPrefixOrDefault')
-  external String getPreferredExtnPrefixOrDefault();
+  external JSString getPreferredExtnPrefixOrDefault();
 
   @JS('setPreferredExtnPrefix')
-  external void setPreferredExtnPrefix(String value);
+  external void setPreferredExtnPrefix(JSString value);
 
   @JS('hasPreferredExtnPrefix')
-  external bool hasPreferredExtnPrefix();
+  external JSBoolean hasPreferredExtnPrefix();
 
   @JS('preferredExtnPrefixCount')
-  external int preferredExtnPrefixCount();
+  external JSNumber preferredExtnPrefixCount();
 
   @JS('clearPreferredExtnPrefix')
   external void clearPreferredExtnPrefix();
 
   @JS('getNationalPrefixForParsing')
-  external String getNationalPrefixForParsing();
+  external JSString getNationalPrefixForParsing();
 
   @JS('getNationalPrefixForParsingOrDefault')
-  external String getNationalPrefixForParsingOrDefault();
+  external JSString getNationalPrefixForParsingOrDefault();
 
   @JS('setNationalPrefixForParsing')
-  external void setNationalPrefixForParsing(String value);
+  external void setNationalPrefixForParsing(JSString value);
 
   @JS('hasNationalPrefixForParsing')
-  external bool hasNationalPrefixForParsing();
+  external JSBoolean hasNationalPrefixForParsing();
 
   @JS('nationalPrefixForParsingCount')
-  external int nationalPrefixForParsingCount();
+  external JSNumber nationalPrefixForParsingCount();
 
   @JS('clearNationalPrefixForParsing')
   external void clearNationalPrefixForParsing();
 
   @JS('getNationalPrefixTransformRule')
-  external String getNationalPrefixTransformRule();
+  external JSString getNationalPrefixTransformRule();
 
   @JS('getNationalPrefixTransformRuleOrDefault')
-  external String getNationalPrefixTransformRuleOrDefault();
+  external JSString getNationalPrefixTransformRuleOrDefault();
 
   @JS('setNationalPrefixTransformRule')
-  external void setNationalPrefixTransformRule(String value);
+  external void setNationalPrefixTransformRule(JSString value);
 
   @JS('hasNationalPrefixTransformRule')
-  external bool hasNationalPrefixTransformRule();
+  external JSBoolean hasNationalPrefixTransformRule();
 
   @JS('nationalPrefixTransformRuleCount')
-  external int nationalPrefixTransformRuleCount();
+  external JSNumber nationalPrefixTransformRuleCount();
 
   @JS('clearNationalPrefixTransformRule')
   external void clearNationalPrefixTransformRule();
 
   @JS('getSameMobileAndFixedLinePattern')
-  external String getSameMobileAndFixedLinePattern();
+  external JSString getSameMobileAndFixedLinePattern();
 
   @JS('getSameMobileAndFixedLinePatternOrDefault')
-  external String getSameMobileAndFixedLinePatternOrDefault();
+  external JSString getSameMobileAndFixedLinePatternOrDefault();
 
   @JS('setSameMobileAndFixedLinePattern')
-  external void setSameMobileAndFixedLinePattern(String value);
+  external void setSameMobileAndFixedLinePattern(JSString value);
 
   @JS('hasSameMobileAndFixedLinePattern')
-  external bool hasSameMobileAndFixedLinePattern();
+  external JSBoolean hasSameMobileAndFixedLinePattern();
 
   @JS('sameMobileAndFixedLinePatternCount')
-  external int sameMobileAndFixedLinePatternCount();
+  external JSNumber sameMobileAndFixedLinePatternCount();
 
   @JS('clearSameMobileAndFixedLinePattern')
   external void clearSameMobileAndFixedLinePattern();
 
   @JS('getNumberFormat')
-  external int getNumberFormat(NumberFormatJsImpl index);
+  external JSNumber getNumberFormat(NumberFormatJsImpl index);
 
   @JS('getNumberFormatOrDefault')
-  external int getNumberFormatOrDefault(NumberFormatJsImpl index);
+  external JSNumber getNumberFormatOrDefault(NumberFormatJsImpl index);
 
   @JS('addNumberFormat')
   external void addNumberFormat(NumberFormatJsImpl value);
 
   @JS('numberFormatArray')
-  external List<NumberFormatJsImpl> numberFormatArray();
+  external JSArray numberFormatArray();
 
   @JS('hasNumberFormat')
-  external bool hasNumberFormat();
+  external JSBoolean hasNumberFormat();
 
   @JS('numberFormatCount')
-  external int numberFormatCount();
+  external JSNumber numberFormatCount();
 
   @JS('clearNumberFormat')
   external void clearNumberFormat();
 
   @JS('getIntlNumberFormat')
-  external int getIntlNumberFormat(NumberFormatJsImpl index);
+  external JSNumber getIntlNumberFormat(NumberFormatJsImpl index);
 
   @JS('getIntlNumberFormatOrDefault')
-  external int getIntlNumberFormatOrDefault(NumberFormatJsImpl index);
+  external JSNumber getIntlNumberFormatOrDefault(NumberFormatJsImpl index);
 
   @JS('addIntlNumberFormat')
   external void addIntlNumberFormat(NumberFormatJsImpl value);
 
   @JS('intlNumberFormatArray')
-  external List<NumberFormatJsImpl> intlNumberFormatArray();
+  external JSArray intlNumberFormatArray();
 
   @JS('hasIntlNumberFormat')
-  external bool hasIntlNumberFormat();
+  external JSBoolean hasIntlNumberFormat();
 
   @JS('intlNumberFormatCount')
-  external int intlNumberFormatCount();
+  external JSNumber intlNumberFormatCount();
 
   @JS('clearIntlNumberFormat')
   external void clearIntlNumberFormat();
 
   @JS('getMainCountryForCode')
-  external bool getMainCountryForCode();
+  external JSBoolean getMainCountryForCode();
 
   @JS('getMainCountryForCodeOrDefault')
-  external bool getMainCountryForCodeOrDefault();
+  external JSBoolean getMainCountryForCodeOrDefault();
 
   @JS('setMainCountryForCode')
-  external void setMainCountryForCode(bool value);
+  external void setMainCountryForCode(JSBoolean value);
 
   @JS('hasMainCountryForCode')
-  external bool hasMainCountryForCode();
+  external JSBoolean hasMainCountryForCode();
 
   @JS('mainCountryForCodeCount')
-  external int mainCountryForCodeCount();
+  external JSNumber mainCountryForCodeCount();
 
   @JS('clearMainCountryForCode')
   external void clearMainCountryForCode();
 
   @JS('getLeadingDigits')
-  external String getLeadingDigits();
+  external JSString getLeadingDigits();
 
   @JS('getLeadingDigitsOrDefault')
-  external String getLeadingDigitsOrDefault();
+  external JSString getLeadingDigitsOrDefault();
 
   @JS('setLeadingDigits')
-  external void setLeadingDigits(String value);
+  external void setLeadingDigits(JSString value);
 
   @JS('hasLeadingDigits')
-  external bool hasLeadingDigits();
+  external JSBoolean hasLeadingDigits();
 
   @JS('leadingDigitsCount')
-  external int leadingDigitsCount();
+  external JSNumber leadingDigitsCount();
 
   @JS('clearLeadingDigits')
   external void clearLeadingDigits();
 
   @JS('getLeadingZeroPossible')
-  external bool getLeadingZeroPossible();
+  external JSBoolean getLeadingZeroPossible();
 
   @JS('getLeadingZeroPossibleOrDefault')
-  external bool getLeadingZeroPossibleOrDefault();
+  external JSBoolean getLeadingZeroPossibleOrDefault();
 
   @JS('setLeadingZeroPossible')
-  external void setLeadingZeroPossible(bool value);
+  external void setLeadingZeroPossible(JSBoolean value);
 
   @JS('hasLeadingZeroPossible')
-  external bool hasLeadingZeroPossible();
+  external JSBoolean hasLeadingZeroPossible();
 
   @JS('leadingZeroPossibleCount')
-  external int leadingZeroPossibleCount();
+  external JSNumber leadingZeroPossibleCount();
 
   @JS('clearLeadingZeroPossible')
   external void clearLeadingZeroPossible();
 }
 
-@JS('PhoneMetadataCollection')
-class PhoneMetadataCollectionJsImpl {
+@JS('libphonenumber.PhoneMetadataCollection')
+extension type PhoneMetadataCollectionJsImpl._(JSObject _) implements JSObject {
   @JS('getMetadata')
-  external PhoneMetadataJsImpl getMetadata(int index);
+  external PhoneMetadataJsImpl getMetadata(JSNumber index);
 
   @JS('getMetadataOrDefault')
-  external PhoneMetadataJsImpl getLeadingZeroPossibleOrDefault(int index);
+  external PhoneMetadataJsImpl getMetadataOrDefault(JSNumber index);
 
   @JS('addMetadata')
   external void addMetadata(PhoneMetadataJsImpl value);
 
   @JS('metadataArray')
-  external List<PhoneMetadataJsImpl> metadataArray();
+  external JSArray metadataArray();
 
   @JS('hasMetadata')
-  external bool hasMetadata();
+  external JSBoolean hasMetadata();
 
   @JS('metadataCount')
-  external int metadataCount();
+  external JSNumber metadataCount();
 
   @JS('clearMetadata')
   external void clearMetadata();

--- a/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumber_interop.dart
@@ -1,111 +1,111 @@
-part of libphonenumber_interop;
+import 'dart:js_interop';
 
-@JS('PhoneNumber')
-class PhoneNumberJsImpl {
+@JS('libphonenumber.PhoneNumber')
+extension type PhoneNumberJsImpl._(JSObject _) implements JSObject {
   @JS('getCountryCode')
-  external int getCountryCode();
+  external JSNumber getCountryCode();
 
   @JS('getCountryCodeOrDefault')
-  external int getCountryCodeOrDefault();
+  external JSNumber getCountryCodeOrDefault();
 
   @JS('setCountryCode')
-  external void setCountryCode(int value);
+  external void setCountryCode(JSNumber value);
 
   @JS('hasCountryCode')
-  external bool hasCountryCode();
+  external JSBoolean hasCountryCode();
 
   @JS('countryCodeCount')
-  external int countryCodeCount();
+  external JSNumber countryCodeCount();
 
   @JS('clearCountryCode')
   external void clearCountryCode();
 
   @JS('getNationalNumber')
-  external int getNationalNumber();
+  external JSNumber getNationalNumber();
 
   @JS('getNationalNumberOrDefault')
-  external int getNationalNumberOrDefault();
+  external JSNumber getNationalNumberOrDefault();
 
   @JS('setNationalNumber')
-  external void setNationalNumber(int value);
+  external void setNationalNumber(JSNumber value);
 
   @JS('hasNationalNumber')
-  external bool hasNationalNumber();
+  external JSBoolean hasNationalNumber();
 
   @JS('nationalNumberCount')
-  external int nationalNumberCount();
+  external JSNumber nationalNumberCount();
 
   @JS('clearNationalNumber')
   external void clearNationalNumber();
 
   @JS('getExtension')
-  external String getExtension();
+  external JSString getExtension();
 
   @JS('getExtensionOrDefault')
-  external String getExtensionOrDefault();
+  external JSString getExtensionOrDefault();
 
   @JS('setExtension')
-  external void setExtension(String value);
+  external void setExtension(JSString value);
 
   @JS('hasExtension')
-  external bool hasExtension();
+  external JSBoolean hasExtension();
 
   @JS('extensionCount')
-  external int extensionCount();
+  external JSNumber extensionCount();
 
   @JS('clearExtension')
   external void clearExtension();
 
   @JS('getItalianLeadingZero')
-  external bool getItalianLeadingZero();
+  external JSBoolean getItalianLeadingZero();
 
   @JS('getItalianLeadingZeroOrDefault')
-  external bool getItalianLeadingZeroOrDefault();
+  external JSBoolean getItalianLeadingZeroOrDefault();
 
   @JS('setItalianLeadingZero')
-  external void setItalianLeadingZero(bool value);
+  external void setItalianLeadingZero(JSBoolean value);
 
   @JS('hasItalianLeadingZero')
-  external bool hasItalianLeadingZero();
+  external JSBoolean hasItalianLeadingZero();
 
   @JS('italianLeadingZeroCount')
-  external int italianLeadingZeroCount();
+  external JSNumber italianLeadingZeroCount();
 
   @JS('clearItalianLeadingZero')
   external void clearItalianLeadingZero();
 
   @JS('getNumberOfLeadingZeros')
-  external int getNumberOfLeadingZeros();
+  external JSNumber getNumberOfLeadingZeros();
 
   @JS('getNumberOfLeadingZerosOrDefault')
-  external int getNumberOfLeadingZerosOrDefault();
+  external JSNumber getNumberOfLeadingZerosOrDefault();
 
   @JS('setNumberOfLeadingZeros')
-  external void setNumberOfLeadingZeros(int value);
+  external void setNumberOfLeadingZeros(JSNumber value);
 
   @JS('hasNumberOfLeadingZeros')
-  external bool hasNumberOfLeadingZeros();
+  external JSBoolean hasNumberOfLeadingZeros();
 
   @JS('numberOfLeadingZerosCount')
-  external int numberOfLeadingZerosCount();
+  external JSNumber numberOfLeadingZerosCount();
 
   @JS('clearNumberOfLeadingZeros')
   external void clearNumberOfLeadingZeros();
 
   @JS('getRawInput')
-  external String getRawInput();
+  external JSString getRawInput();
 
   @JS('getRawInputOrDefault')
-  external String getRawInputOrDefault();
+  external JSString getRawInputOrDefault();
 
   @JS('setRawInput')
-  external void setRawInput(String value);
+  external void setRawInput(JSString value);
 
   @JS('hasRawInput')
-  external bool hasRawInput();
+  external JSBoolean hasRawInput();
 
   @JS('rawInputCount')
-  external int rawInputCount();
+  external JSNumber rawInputCount();
 
   @JS('clearRawInput')
   external void clearRawInput();
@@ -124,19 +124,19 @@ class PhoneNumberJsImpl {
   ///
 
   @JS('getCountryCodeSource')
-  external int getCountryCodeSource();
+  external JSNumber getCountryCodeSource();
 
   @JS('getCountryCodeSourceOrDefault')
-  external int getCountryCodeSourceOrDefault();
+  external JSNumber getCountryCodeSourceOrDefault();
 
   @JS('setCountryCodeSource')
-  external void setCountryCodeSource(int value);
+  external void setCountryCodeSource(JSNumber value);
 
   @JS('hasCountryCodeSource')
-  external bool hasCountryCodeSource();
+  external JSBoolean hasCountryCodeSource();
 
   @JS('countryCodeSourceCount')
-  external int countryCodeSourceCount();
+  external JSNumber countryCodeSourceCount();
 
   @JS('clearCountryCodeSource')
   external void clearCountryCodeSource();
@@ -144,19 +144,19 @@ class PhoneNumberJsImpl {
   // END
 
   @JS('getPreferredDomesticCarrierCode')
-  external String getPreferredDomesticCarrierCode();
+  external JSString getPreferredDomesticCarrierCode();
 
   @JS('getPreferredDomesticCarrierCodeOrDefault')
-  external String getPreferredDomesticCarrierCodeOrDefault();
+  external JSString getPreferredDomesticCarrierCodeOrDefault();
 
   @JS('setPreferredDomesticCarrierCode')
-  external void setPreferredDomesticCarrierCode(String value);
+  external void setPreferredDomesticCarrierCode(JSString value);
 
   @JS('hasPreferredDomesticCarrierCode')
-  external bool hasPreferredDomesticCarrierCode();
+  external JSBoolean hasPreferredDomesticCarrierCode();
 
   @JS('preferredDomesticCarrierCodeCount')
-  external int preferredDomesticCarrierCodeCount();
+  external JSNumber preferredDomesticCarrierCodeCount();
 
   @JS('clearPreferredDomesticCarrierCode')
   external void clearPreferredDomesticCarrierCode();

--- a/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
+++ b/libphonenumber_web/lib/src/interop/phonenumberutil_interop.dart
@@ -1,47 +1,49 @@
-part of libphonenumber_interop;
+import 'dart:js_interop';
+import './phonenumber_interop.dart'; // For PhoneNumberJsImpl
+import './phonemetadata_interop.dart'; // For PhoneMetadataJsImpl, NumberFormatJsImpl
+import './utils/stringbuffer.dart'; // For StringBufferJsImpl
 
-@JS('PhoneNumberUtil')
-class PhoneNumberUtilJsImpl {
-  external PhoneNumberUtilJsImpl._();
-
+@JS('libphonenumber.PhoneNumberUtil')
+extension type PhoneNumberUtilJsImpl._(JSObject _) implements JSObject {
   @JS('getInstance')
   external static PhoneNumberUtilJsImpl getInstance();
 
   @JS('extractPossibleNumber')
-  external String extractPossibleNumber(String number);
+  external JSString extractPossibleNumber(JSString number);
 
   @JS('isViablePhoneNumber')
-  external bool isViablePhoneNumber(String number);
+  external JSBoolean isViablePhoneNumber(JSString number);
 
   @JS('normalize')
-  external String normalize(String number);
+  external JSString normalize(JSString number);
 
   @JS('normalizeDigitsOnly')
-  external String normalizeDigitsOnly(String number);
+  external JSString normalizeDigitsOnly(JSString number);
 
   @JS('normalizeDiallableCharsOnly')
-  external String normalizeDiallableCharsOnly(String number);
+  external JSString normalizeDiallableCharsOnly(JSString number);
 
   @JS('convertAlphaCharactersInNumber')
-  external String convertAlphaCharactersInNumber(String number);
+  external JSString convertAlphaCharactersInNumber(JSString number);
 
   @JS('getLengthOfGeographicalAreaCode')
-  external int getLengthOfGeographicalAreaCode(PhoneNumberJsImpl number);
+  external JSNumber getLengthOfGeographicalAreaCode(PhoneNumberJsImpl number);
 
   @JS('getLengthOfNationalDestinationCode')
-  external int getLengthOfNationalDestinationCode(PhoneNumberJsImpl number);
+  external JSNumber getLengthOfNationalDestinationCode(
+      PhoneNumberJsImpl number);
 
   @JS('getCountryMobileToken')
-  external String getCountryMobileToken(int countryCallingCode);
+  external JSString getCountryMobileToken(JSNumber countryCallingCode);
 
   @JS('getSupportedRegions')
-  external List<dynamic> getSupportedRegions();
+  external JSArray getSupportedRegions();
 
   @JS('getSupportedGlobalNetworkCallingCodes')
-  external List<int> getSupportedGlobalNetworkCallingCodes();
+  external JSArray getSupportedGlobalNetworkCallingCodes();
 
   @JS('getSupportedCallingCodes')
-  external List<int> getSupportedCallingCodes();
+  external JSArray getSupportedCallingCodes();
 
   ///
   ///   * Type of phone numbers.
@@ -81,170 +83,169 @@ class PhoneNumberUtilJsImpl {
   ///
 
   @JS('getSupportedTypesForRegion')
-  external List<int> getSupportedTypesForRegion(String regionCode);
+  external JSArray getSupportedTypesForRegion(JSString regionCode);
 
   @JS('getSupportedTypesForNonGeoEntity')
-  external List<int> getSupportedTypesForNonGeoEntity(String regionCode);
+  external JSArray getSupportedTypesForNonGeoEntity(JSString regionCode);
 
   @JS('formattingRuleHasFirstGroupOnly')
-  external bool formattingRuleHasFirstGroupOnly(
-      String nationalPrefixFormattingRule);
+  external JSBoolean formattingRuleHasFirstGroupOnly(
+      JSString nationalPrefixFormattingRule);
 
   @JS('isNumberGeographical')
-  external bool isNumberGeographical(PhoneNumberJsImpl number);
+  external JSBoolean isNumberGeographical(PhoneNumberJsImpl number);
 
   @JS('format')
-  external String format(PhoneNumberJsImpl number, int numberFormat);
+  external JSString format(PhoneNumberJsImpl number, JSNumber numberFormat);
 
   @JS('formatByPattern')
-  external String formatByPattern(PhoneNumberJsImpl number, int numberFormat,
-      NumberFormatJsImpl userDefineFormat);
+  external JSString formatByPattern(PhoneNumberJsImpl number,
+      JSNumber numberFormat, NumberFormatJsImpl userDefineFormat);
 
   @JS('formatNationalNumberWithCarrierCode')
-  external String formatNationalNumberWithCarrierCode(
-      PhoneNumberJsImpl number, String carrierCode);
+  external JSString formatNationalNumberWithCarrierCode(
+      PhoneNumberJsImpl number, JSString carrierCode);
 
   @JS('formatNationalNumberWithPreferredCarrierCode')
-  external String formatNationalNumberWithPreferredCarrierCode(
-      PhoneNumberJsImpl number, String fallbackCarrierCode);
+  external JSString formatNationalNumberWithPreferredCarrierCode(
+      PhoneNumberJsImpl number, JSString fallbackCarrierCode);
 
   @JS('formatNumberForMobileDialing')
-  external String formatNumberForMobileDialing(
-      PhoneNumberJsImpl number, String regionCallingFrom, bool withFormatting);
+  external JSString formatNumberForMobileDialing(PhoneNumberJsImpl number,
+      JSString regionCallingFrom, JSBoolean withFormatting);
 
   @JS('formatOutOfCountryCallingNumber')
-  external String formatOutOfCountryCallingNumber(
-      PhoneNumberJsImpl number, String regionCallingFrom);
+  external JSString formatOutOfCountryCallingNumber(
+      PhoneNumberJsImpl number, JSString regionCallingFrom);
 
   @JS('formatInOriginalFormat')
-  external String formatInOriginalFormat(
-      PhoneNumberJsImpl number, String regionCallingFrom);
+  external JSString formatInOriginalFormat(
+      PhoneNumberJsImpl number, JSString regionCallingFrom);
 
   @JS('formatOutOfCountryKeepingAlphaChars')
-  external String formatOutOfCountryKeepingAlphaChars(
-      PhoneNumberJsImpl number, String regionCallingFrom);
+  external JSString formatOutOfCountryKeepingAlphaChars(
+      PhoneNumberJsImpl number, JSString regionCallingFrom);
 
   @JS('getNationalSignificantNumber')
-  external String getNationalSignificantNumber(PhoneNumberJsImpl number);
+  external JSString getNationalSignificantNumber(PhoneNumberJsImpl number);
 
   @JS('getExampleNumber')
-  external PhoneNumberJsImpl getExampleNumber(String regionCode);
+  external PhoneNumberJsImpl getExampleNumber(JSString regionCode);
 
   @JS('getExampleNumberForType')
   external PhoneNumberJsImpl getExampleNumberForType(
-      String regionCode, int type);
+      JSString regionCode, JSNumber type);
 
   @JS('getExampleNumberForNonGeoEntity')
   external PhoneNumberJsImpl getExampleNumberForNonGeoEntity(
-      int countryCallingCode);
+      JSNumber countryCallingCode);
 
   @JS('getNumberType')
-  external int getNumberType(PhoneNumberJsImpl number);
+  external JSNumber getNumberType(PhoneNumberJsImpl number);
 
   @JS('getMetadataForRegion')
-  external PhoneMetadataJsImpl getMetadataForRegion(String regionCode);
+  external PhoneMetadataJsImpl getMetadataForRegion(JSString regionCode);
 
   @JS('getMetadataForNonGeographicalRegion')
   external PhoneMetadataJsImpl getMetadataForNonGeographicalRegion(
-      int countryCallingCode);
+      JSNumber countryCallingCode);
 
   @JS('isValidNumber')
-  external bool isValidNumber(PhoneNumberJsImpl number);
+  external JSBoolean isValidNumber(PhoneNumberJsImpl number);
 
   @JS('isValidNumberForRegion')
-  external bool isValidNumberForRegion(
-      PhoneNumberJsImpl number, String regionCode);
+  external JSBoolean isValidNumberForRegion(
+      PhoneNumberJsImpl number, JSString regionCode);
 
   @JS('getRegionCodeForNumber')
-  external String getRegionCodeForNumber(PhoneNumberJsImpl number);
+  external JSString getRegionCodeForNumber(PhoneNumberJsImpl number);
 
   @JS('getRegionCodeForCountryCode')
-  external String getRegionCodeForCountryCode(int countryCallingCode);
+  external JSString getRegionCodeForCountryCode(JSNumber countryCallingCode);
 
   @JS('getCountryCodeForRegion')
-  external int getCountryCodeForRegion(String regionCode);
+  external JSNumber getCountryCodeForRegion(JSString regionCode);
 
   @JS('getNddPrefixForRegion')
-  external String getNddPrefixForRegion(
-      String regionCode, bool stripeNonDigits);
+  external JSString getNddPrefixForRegion(
+      JSString regionCode, JSBoolean stripeNonDigits);
 
   @JS('isNANPACountry')
-  external bool isNANPACountry(String regionCode);
+  external JSBoolean isNANPACountry(JSString regionCode);
 
   @JS('isAlphaNumber')
-  external bool isAlphaNumber(String number);
+  external JSBoolean isAlphaNumber(JSString number);
 
   @JS('isPossibleNumber')
-  external bool isPossibleNumber(PhoneNumberJsImpl number);
+  external JSBoolean isPossibleNumber(PhoneNumberJsImpl number);
 
   @JS('isPossibleNumberForType')
-  external bool isPossibleNumberForType(PhoneNumberJsImpl number, int type);
+  external JSBoolean isPossibleNumberForType(
+      PhoneNumberJsImpl number, JSNumber type);
 
   @JS('isPossibleNumberWithReason')
-  external bool isPossibleNumberWithReason(PhoneNumberJsImpl number);
+  external JSBoolean isPossibleNumberWithReason(PhoneNumberJsImpl number);
 
   @JS('isPossibleNumberForTypeWithReason')
-  external bool isPossibleNumberForTypeWithReason(
-      PhoneNumberJsImpl number, int type);
+  external JSBoolean isPossibleNumberForTypeWithReason(
+      PhoneNumberJsImpl number, JSNumber type);
 
   @JS('isPossibleNumberString')
-  external bool isPossibleNumberString(
-      String number, String regionDialiingFrom);
+  external JSBoolean isPossibleNumberString(
+      JSString number, JSString regionDialiingFrom);
 
   @JS('truncateTooLongNumber')
-  external bool truncateTooLongNumber(PhoneNumberJsImpl number);
+  external JSBoolean truncateTooLongNumber(PhoneNumberJsImpl number);
 
   @JS('extractCountryCode')
-  external int extractCountryCode(
+  external JSNumber extractCountryCode(
       StringBufferJsImpl fullNumber, StringBufferJsImpl nationalNumber);
 
   @JS('maybeExtractCountryCode')
-  external int maybeExtractCountryCode(
-      String number,
+  external JSNumber maybeExtractCountryCode(
+      JSString number,
       PhoneMetadataJsImpl defaultRegionMetadata,
       StringBufferJsImpl nationalNumber,
-      bool keepRawInput,
+      JSBoolean keepRawInput,
       PhoneNumberJsImpl phoneNumber);
 
   @JS('maybeStripInternationalPrefixAndNormalize')
-  external int maybeStripInternationalPrefixAndNormalize(
-      StringBufferJsImpl number, String possibleIddPrefix);
+  external JSString maybeStripInternationalPrefixAndNormalize(
+      StringBufferJsImpl number, JSString possibleIddPrefix);
 
   @JS('maybeStripNationalPrefixAndCarrierCode')
-  external bool maybeStripNationalPrefixAndCarrierCode(
+  external JSBoolean maybeStripNationalPrefixAndCarrierCode(
       StringBufferJsImpl number,
       PhoneMetadataJsImpl metadata,
       StringBufferJsImpl carrierCode);
 
   @JS('maybeStripExtension')
-  external String maybeStripExtension(StringBufferJsImpl number);
+  external JSString maybeStripExtension(StringBufferJsImpl number);
 
   @JS('parse')
-  external PhoneNumberJsImpl parse(String numberToParse, String defaultRegion);
+  external PhoneNumberJsImpl parse(
+      JSString numberToParse, JSString defaultRegion);
 
   @JS('parseAndKeepRawInput')
   external PhoneNumberJsImpl parseAndKeepRawInput(
-      String numberToParse, String defaultRegion);
+      JSString numberToParse, JSString defaultRegion);
 
   @JS('isNumberMatch')
-  external int isNumberMatch(String firstNumberIn, String secondNumberIn);
-
-  @JS('isNumberMatch')
-  external int isPhoneNumberMatch(
+  external JSNumber isNumberMatch(
       PhoneNumberJsImpl firstNumberIn, PhoneNumberJsImpl secondNumberIn);
 
   @JS('canBeInternationallyDialled')
-  external bool canBeInternationallyDialled(PhoneNumberJsImpl number);
+  external JSBoolean canBeInternationallyDialled(PhoneNumberJsImpl number);
 
   /// TODO:
   ///
   /// Try this with regexp object from dart
   ///
   @JS('matchesEntirely')
-  external bool matchesEntirely(String regex, String str);
+  external JSBoolean matchesEntirely(JSString regex, JSString str);
 
   @JS('matchesPrefix')
-  external bool matchesPrefix(String regex, String str);
+  external JSBoolean matchesPrefix(JSString regex, JSString str);
 
   ///
   /// End of Regexp test

--- a/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
+++ b/libphonenumber_web/lib/src/interop/shortnumberinfo_interop.dart
@@ -1,54 +1,57 @@
-part of libphonenumber_interop;
+import 'dart:js_interop';
+import './phonenumber_interop.dart'; // For PhoneNumberJsImpl
 
-@JS('ShortNumberInfo')
-class ShortNumberInfoJsImpl {
+@JS('libphonenumber.ShortNumberInfo')
+extension type ShortNumberInfoJsImpl._(JSObject _) implements JSObject {
   @JS('getInstance')
   external static ShortNumberInfoJsImpl getInstance();
 
   @JS('isPossibleShortNumberForRegion')
-  external bool isPossibleShortNumberForRegion(
-      PhoneNumberJsImpl number, String regionDialingFrom);
+  external JSBoolean isPossibleShortNumberForRegion(
+      PhoneNumberJsImpl number, JSString regionDialingFrom);
 
   @JS('isPossibleShortNumber')
-  external bool isPossibleShortNumber(PhoneNumberJsImpl number);
+  external JSBoolean isPossibleShortNumber(PhoneNumberJsImpl number);
 
   @JS('isValidShortNumberForRegion')
-  external bool isValidShortNumberForRegion(
-      PhoneNumberJsImpl number, String regionDialingFrom);
+  external JSBoolean isValidShortNumberForRegion(
+      PhoneNumberJsImpl number, JSString regionDialingFrom);
 
   @JS('isValidShortNumber')
-  external bool isValidShortNumber(PhoneNumberJsImpl number);
+  external JSBoolean isValidShortNumber(PhoneNumberJsImpl number);
 
   @JS('getExpectedCostForRegion')
-  external int getExpectedCostForRegion(
-      PhoneNumberJsImpl number, String regionDialingFrom);
+  external JSNumber getExpectedCostForRegion(
+      PhoneNumberJsImpl number, JSString regionDialingFrom);
 
   @JS('getExpectedCost')
-  external int getExpectedCost(PhoneNumberJsImpl number);
+  external JSNumber getExpectedCost(PhoneNumberJsImpl number);
 
   @JS('getSupportedRegions')
-  external List<String> getSupportedRegions();
+  external JSArray getSupportedRegions();
 
   @JS('getExampleShortNumber')
-  external String getExampleShortNumber(String regionCode);
+  external JSString getExampleShortNumber(JSString regionCode);
 
   @JS('getExampleShortNumberForCost')
-  external String getExampleShortNumberForCost(String regionCode, int cost);
+  external JSString getExampleShortNumberForCost(
+      JSString regionCode, JSNumber cost);
 
   @JS('connectsToEmergencyNumber')
-  external bool connectsToEmergencyNumber(String number, String regionCode);
+  external JSBoolean connectsToEmergencyNumber(
+      JSString number, JSString regionCode);
 
   @JS('isEmergencyNumber')
-  external bool isEmergencyNumber(String number, String regionCode);
+  external JSBoolean isEmergencyNumber(JSString number, JSString regionCode);
 
   @JS('isCarrierSpecific')
-  external bool isCarrierSpecific(PhoneNumberJsImpl number);
+  external JSBoolean isCarrierSpecific(PhoneNumberJsImpl number);
 
   @JS('isCarrierSpecificForRegion')
-  external bool isCarrierSpecificForRegion(
-      PhoneNumberJsImpl number, String regionDialingFrom);
+  external JSBoolean isCarrierSpecificForRegion(
+      PhoneNumberJsImpl number, JSString regionDialingFrom);
 
   @JS('isSmsServiceForRegion')
-  external bool isSmsServiceForRegion(
-      PhoneNumberJsImpl number, String regionDialingFrom);
+  external JSBoolean isSmsServiceForRegion(
+      PhoneNumberJsImpl number, JSString regionDialingFrom);
 }

--- a/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
+++ b/libphonenumber_web/lib/src/interop/utils/stringbuffer.dart
@@ -1,27 +1,23 @@
 // ignore_for_file: annotate_overrides
 
-@JS()
-library stringbuffer;
+import 'dart:js_interop';
 
-import 'package:js/js.dart';
-
-@JS('StringBuffer')
-class StringBufferJsImpl {
-  external StringBufferJsImpl(dynamic optA1, [dynamic varArgs = '']);
+@JS('libphonenumber.StringBuffer')
+extension type StringBufferJsImpl._(JSObject _) implements JSObject {
+  external StringBufferJsImpl([JSAny? optA1, JSAny? varArgs]);
 
   @JS('set')
-  external void set(dynamic s);
+  external void set(JSAny s);
 
   @JS('append')
-  external StringBufferJsImpl append(
-      dynamic a1, dynamic optA2, dynamic varArgs);
+  external StringBufferJsImpl append(JSAny a1, [JSAny? optA2, JSAny? optA3]);
 
   @JS('clear')
   external void clear();
 
   @JS('getLength')
-  external int getLength();
+  external JSNumber getLength();
 
   @JS('toString')
-  external String toString();
+  external JSString toString$();
 }

--- a/libphonenumber_web/lib/src/libphonenumber_plugin.dart
+++ b/libphonenumber_web/lib/src/libphonenumber_plugin.dart
@@ -1,3 +1,4 @@
+import 'dart:js_interop';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:libphonenumber_platform_interface/libphonenumber_platform_interface.dart';
 import 'package:libphonenumber_web/src/interop/libphonenumber_interop.dart';
@@ -14,7 +15,7 @@ class LibPhoneNumberPlugin extends LibPhoneNumberPlatform {
     String? result;
 
     for (int i = 0; i < phoneNumber.length; i++) {
-      result = phoneUtilJsImpl.inputDigit(phoneNumber[i]);
+      result = phoneUtilJsImpl.inputDigit(phoneNumber[i].toJS).toDart;
     }
 
     return result;
@@ -24,9 +25,9 @@ class LibPhoneNumberPlugin extends LibPhoneNumberPlatform {
   Future<int?> getNumberType(String phoneNumber, String isoCode) async {
     PhoneNumberUtilJsImpl phoneUtilJsImpl = PhoneNumberUtilJsImpl.getInstance();
     PhoneNumberJsImpl phoneNumberJsImpl =
-        phoneUtilJsImpl.parse(phoneNumber, isoCode.toUpperCase());
+        phoneUtilJsImpl.parse(phoneNumber.toJS, isoCode.toUpperCase().toJS);
 
-    int index = phoneUtilJsImpl.getNumberType(phoneNumberJsImpl);
+    int index = phoneUtilJsImpl.getNumberType(phoneNumberJsImpl).toDartInt;
 
     return index;
   }
@@ -36,13 +37,15 @@ class LibPhoneNumberPlugin extends LibPhoneNumberPlatform {
       String phoneNumber, String isoCode) async {
     PhoneNumberUtilJsImpl phoneUtilJsImpl = PhoneNumberUtilJsImpl.getInstance();
     PhoneNumberJsImpl phoneNumberJsImpl =
-        phoneUtilJsImpl.parse(phoneNumber, isoCode.toUpperCase());
+        phoneUtilJsImpl.parse(phoneNumber.toJS, isoCode.toUpperCase().toJS);
 
     String regionCode =
-        phoneUtilJsImpl.getRegionCodeForNumber(phoneNumberJsImpl);
-    String countryCode = phoneNumberJsImpl.getCountryCode().toString();
-    String formattedNumber = phoneUtilJsImpl.format(
-        phoneNumberJsImpl, PhoneNumberFormat.NATIONAL.value);
+        phoneUtilJsImpl.getRegionCodeForNumber(phoneNumberJsImpl).toDart;
+    String countryCode =
+        phoneNumberJsImpl.getCountryCode().toDartInt.toString();
+    String formattedNumber = phoneUtilJsImpl
+        .format(phoneNumberJsImpl, PhoneNumberFormat.NATIONAL.value.toJS)
+        .toDart;
 
     RegionInfo info = RegionInfo(
         regionPrefix: countryCode,
@@ -56,20 +59,20 @@ class LibPhoneNumberPlugin extends LibPhoneNumberPlatform {
   Future<bool?> isValidPhoneNumber(String phoneNumber, String isoCode) async {
     PhoneNumberUtilJsImpl phoneUtilJsImpl = PhoneNumberUtilJsImpl.getInstance();
     PhoneNumberJsImpl phoneNumberJsImpl =
-        phoneUtilJsImpl.parse(phoneNumber, isoCode.toUpperCase());
+        phoneUtilJsImpl.parse(phoneNumber.toJS, isoCode.toUpperCase().toJS);
 
-    return phoneUtilJsImpl.isValidNumber(phoneNumberJsImpl);
+    return phoneUtilJsImpl.isValidNumber(phoneNumberJsImpl).toDart;
   }
 
   @override
-  Future<String?> normalizePhoneNumber(
-      String phoneNumber, String isoCode, [PhoneNumberFormat format = PhoneNumberFormat.E164]) async {
+  Future<String?> normalizePhoneNumber(String phoneNumber, String isoCode,
+      [PhoneNumberFormat format = PhoneNumberFormat.E164]) async {
     PhoneNumberUtilJsImpl phoneUtilJsImpl = PhoneNumberUtilJsImpl.getInstance();
     PhoneNumberJsImpl phoneNumberJsImpl =
-        phoneUtilJsImpl.parse(phoneNumber, isoCode.toUpperCase());
+        phoneUtilJsImpl.parse(phoneNumber.toJS, isoCode.toUpperCase().toJS);
 
     String normalized =
-        phoneUtilJsImpl.format(phoneNumberJsImpl, format.value);
+        phoneUtilJsImpl.format(phoneNumberJsImpl, format.value.toJS).toDart;
 
     return normalized;
   }
@@ -78,10 +81,9 @@ class LibPhoneNumberPlugin extends LibPhoneNumberPlatform {
   Future<List<String>?> getAllCountries() async {
     PhoneNumberUtilJsImpl phoneUtilJsImpl = PhoneNumberUtilJsImpl.getInstance();
 
-    final allCountries = phoneUtilJsImpl
-        .getSupportedRegions()
-        .map<String>((e) => e as String)
-        .toList();
+    final JSArray jsArray = phoneUtilJsImpl.getSupportedRegions();
+    final List<String> allCountries =
+        jsArray.toDart.map((e) => (e as JSString).toDart).toList();
 
     return allCountries;
   }
@@ -95,14 +97,16 @@ class LibPhoneNumberPlugin extends LibPhoneNumberPlatform {
     PhoneNumberUtilJsImpl phoneUtilJsImpl = PhoneNumberUtilJsImpl.getInstance();
 
     PhoneNumberJsImpl exampleNumber = phoneUtilJsImpl.getExampleNumberForType(
-      isoCode,
-      type.value,
+      isoCode.toJS,
+      type.value.toJS,
     );
 
-    String formattedExampleNumber = phoneUtilJsImpl.format(
-      exampleNumber,
-      format.value,
-    );
+    String formattedExampleNumber = phoneUtilJsImpl
+        .format(
+          exampleNumber,
+          format.value.toJS,
+        )
+        .toDart;
 
     return formattedExampleNumber;
   }

--- a/libphonenumber_web/pubspec.yaml
+++ b/libphonenumber_web/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.3.2
 homepage: https://github.com/natintosh/plugin_libphonenumber.git
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: ">=1.20.0"
 
 dependencies:
@@ -13,7 +13,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  js: ^0.6.7
   libphonenumber_platform_interface: ^0.4.2
 
 dev_dependencies:


### PR DESCRIPTION
Closes #38.

I encountered this issue while trying to build a Flutter web app using WebAssembly, which includes [intl_phone_number_input](https://pub.dev/packages/intl_phone_number_input) as a dependency—and thus, this plugin as a transitive dependency.

I ran a migration to use next-generation JS interop using gemini-2.5-pro, which resolved the issue.

I'm overriding the dependency as follows:

```
dependency_overrides:
  libphonenumber_web:
    git:
      url: https://github.com/Kal-Elx/plugin_libphonenumber.git
      ref: migrate_to_next_gen_js_interop
      path: libphonenumber_web
```

I've verified that the changes work by running the example project in intl_phone_number_input.

This is the extent of the testing I’ve done. I'm confident including it in my app, but for further quality assurance, I defer to the maintainers of this package.